### PR TITLE
Dependabot更新のグルーピング設定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+
+multi-ecosystem-groups:
+  dependency-updates:
+    schedule:
+      interval: "weekly"
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "dependency-updates"
+    groups:
+      all-github-actions-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
### Motivation
- DependabotのPRノイズを低減するため、GitHub Actionsの通常更新とセキュリティ更新を週次の`dependency-updates`マルチエコシステムグループへまとめる設定を追加します。

### Description
-  ` .github/dependabot.yml` を追加し `version: 2` を指定したうえで `multi-ecosystem-groups` に `dependency-updates` を週次スケジュールで定義し、`package-ecosystem: "github-actions"` を `patterns: ["*"]` で対象化して `multi-ecosystem-group: "dependency-updates"` に割り当て、`all-github-actions-security-updates` グループでセキュリティ更新をまとめる設定を追加しました。

### Testing
- 実行した自動テストは `ruby -e 'require "yaml"; data = YAML.load_file(".github/dependabot.yml"); abort("bad version") unless data["version"] == 2; abort("missing multi-ecosystem-groups") unless data["multi-ecosystem-groups"].is_a?(Hash); group = data.dig("multi-ecosystem-groups", "dependency-updates"); abort("missing weekly group schedule") unless group.dig("schedule", "interval") == "weekly"; updates = data["updates"]; abort("bad updates") unless updates.is_a?(Array) && updates.size == 1; update = updates.first; abort("bad ecosystem") unless update["package-ecosystem"] == "github-actions"; abort("bad patterns") unless update["patterns"] == ["*"]; abort("bad multi group") unless update["multi-ecosystem-group"] == "dependency-updates"; security_group = update.dig("groups", "all-github-actions-security-updates"); abort("bad security group") unless security_group && security_group["applies-to"] == "security-updates" && security_group["patterns"] == ["*"]; puts "dependabot.yml is valid YAML"'` と `git diff --cached --check` で、両方とも成功しました.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b7e90f84832698490537faa90a2a)